### PR TITLE
Adding BDD features and tests python behave

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,44 @@
 # dojo Grupy-PR
 
 Respositório contendo o código das sessões de dojo do Grupy-PR.
+
+
+## Testes Unit Test e BDD
+
+A sessões do dojo são feitas com a metodologia TDD e códigos de teste
+escritos em [unittest](https://docs.python.org/3/library/unittest.html).
+
+Alguns testes foram escritos também em BDD com [behave](http://python-behave.readthedocs.io).
+
+
+
+### Unit Test
+
+Para executar os testes em Unit Test, basta rodar os arquivos test_*.py
+
+Exemplo:
+
+    $ cd romanos_20170111
+    $ python test_romanos.py
+
+
+### BDD
+
+Para executar os teste em BDD, é necessário instalar o behave primeiro:
+    
+    $ pip install behave
+
+
+Depois basta rodar o comando behave. Exemplo:
+
+    $ cd romanos_20170111
+    $ behave
+
+
+A saída do behave é mais extensa por padrão, cada passo de cada cenário é impresso. Se preferir uma saída mais compacta, parecida com a do unittest, com um ponto para cada cenário, pode rodar:
+
+    $ behave --format progress
+
+
+
+

--- a/fizzbuzz_20171116/features/play_fizzbuzz_game.feature
+++ b/fizzbuzz_20171116/features/play_fizzbuzz_game.feature
@@ -1,0 +1,46 @@
+Feature: Play FizzBuzz game
+    Fizz buzz is a group word game for children to teach them about division [1].
+    Players take turns to count incrementally, replacing any number divisible
+    by three with the word "fizz", and any number divisible by five with the
+    word "buzz". Numbers divisible by both become "fizzbuzz".
+    [1] https://en.wikipedia.org/wiki/Fizz_buzz
+
+
+    Scenario Outline: Function fizzbuzz should return correclty for each number input
+        When I choose number <number>
+         And call the function
+        Then it should return <fizzbuzz>
+
+    Examples:
+        | number | fizzbuzz   |
+        |   1    |      1     |
+        |   2    |      2     |
+        |   3    |   'fizz'   |
+        |   4    |      4     |
+        |   5    |   'buzz'   |
+        |   6    |   'fizz'   |
+        |   7    |      7     |
+        |   9    |   'fizz'   |
+        |  10    |   'buzz'   |
+        |  15    | 'fizzbuzz' |
+
+
+    Scenario Outline: Method to_fizzbuzz from object Fizzbuzz should return correclty
+        When I choose number <number>
+         And create a FizzBuzzInt object for the number
+         And call the method to_fizzbuzz 
+        Then it should return <fizzbuzz>
+	 And its repr() should match repr(<fizzbuzz>)
+
+    Examples:
+        | number | fizzbuzz   |
+        |   1    |      1     |
+        |   2    |      2     |
+        |   3    |   'fizz'   |
+        |   4    |      4     |
+        |   5    |   'buzz'   |
+        |   6    |   'fizz'   |
+        |   7    |      7     |
+        |   9    |   'fizz'   |
+        |  10    |   'buzz'   |
+        |  15    | 'fizzbuzz' |

--- a/fizzbuzz_20171116/features/steps/fizzbuzz_steps.py
+++ b/fizzbuzz_20171116/features/steps/fizzbuzz_steps.py
@@ -1,0 +1,43 @@
+from fizzbuzz import fizzbuzz, FizzBuzzInt
+
+
+@when('I choose number {number:d}')
+def step_impl(context, number):
+    context.number = number
+
+
+@when('call the function')
+def step_impl(context):
+    context.result = fizzbuzz(context.number)
+
+
+@then('it should return {number:d}')
+def step_impl(context, number):
+    assert context.result == number
+
+
+@then('it should return \'{fizzbuzz_text}\'')
+def step_impl(context, fizzbuzz_text):
+    assert context.result == fizzbuzz_text
+
+
+@when('create a FizzBuzzInt object for the number')
+def step_impl(context):
+    context.obj = FizzBuzzInt(context.number)
+
+
+@when('call the method to_fizzbuzz')
+def step_impl(context):
+    context.result = context.obj.to_fizzbuzz()
+
+
+@then('its repr() should match repr({number:d})')
+def step_impl(context, number):
+    assert repr(context.result) == repr(number)
+
+
+@then('its repr() should match repr(\'{fizzbuzz_text}\')')
+def step_impl(context, fizzbuzz_text):
+    assert repr(context.result) == repr(fizzbuzz_text)
+
+

--- a/jokenpo_20171214/features/play_jokenpo.feature
+++ b/jokenpo_20171214/features/play_jokenpo.feature
@@ -1,0 +1,39 @@
+Feature: Play Jokenpo game
+
+    Scenario Outline: See who is the winner from two hands of play
+        When one player chooses <player1_hand>
+         And the other player chooses <player2_hand>
+         And players show their hands
+        Then the winner hand should be <winner>
+
+        Examples: players hands and winner
+            | player1_hand | player2_hand |  winner    |
+            |    pedra     |    pedra     |  EMPATE    |
+            |    pedra     |    tesoura   |  PEDRA     |
+            |    pedra     |    papel     |  PAPEL     |
+            |    tesoura   |    papel     |  TESOURA   |
+            |    tesoura   |    pedra     |  PEDRA     |
+            |    tesoura   |    tesoura   |  EMPATE    |
+            |    papel     |    papel     |  EMPATE    |
+            |    papel     |    pedra     |  PAPEL     |
+            |    papel     |    tesoura   |  TESOURA   |
+            |    Papel     |    pedra     |  PAPEL     |
+            |    papel     |    Pedra     |  PAPEL     |
+
+
+    Scenario Outline: Try to play with invalid hands
+        When one player chooses <player1_hand>
+         And the other player chooses <player2_hand>
+         And players show their hands
+        Then we should get and error
+
+        Examples: invalid players hands
+            | player1_hand | player2_hand |
+            |    preda     |    preda     |
+            |    tezoura   |    preda     |
+            |    preda     |    tesoura   |
+            |    1         |    pedra     |
+            |    pedra     |    1         |
+            |    None      |    pedra     |
+            |    pedra     |    None      |
+

--- a/jokenpo_20171214/features/steps/jokenpo_steps.py
+++ b/jokenpo_20171214/features/steps/jokenpo_steps.py
@@ -1,0 +1,44 @@
+from jokenpo import jokenpo, JogadaInvalidaError
+
+
+@when('one player chooses None')
+def step_impl(context):
+    context.hand_player1 = None
+
+
+@when('one player chooses {hand:d}')
+def step_impl(context, hand):
+    context.hand_player1 = hand
+
+
+@when('one player chooses {hand}')
+def step_impl(context, hand):
+    context.hand_player1 = hand
+
+
+@when('the other player chooses {hand}')
+def step_impl(context, hand):
+    context.hand_player2 = hand
+
+
+@then('the winner hand should be {winner}')
+def step_impl(context, winner):
+    assert context.exception is None
+    assert context.result == winner
+
+
+@when('players show their hands')
+def step_impl(context):
+    context.exception = None
+    try:
+        context.result = jokenpo(context.hand_player1, context.hand_player2)
+    except Exception as e:
+        context.exception = e
+
+
+@then('we should get and error')
+def step_impl(context):
+    assert isinstance(context.exception, JogadaInvalidaError)
+
+
+

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,0 +1,4 @@
+behave==1.2.5
+parse==1.8.2
+parse-type==0.4.2
+six==1.11.0

--- a/romanos_20170111/features/convert_roman_numbers_to_decimal.feature
+++ b/romanos_20170111/features/convert_roman_numbers_to_decimal.feature
@@ -1,0 +1,29 @@
+Feature: Convert roman number to decimal
+
+    Scenario Outline: Enter a roman number and see it in decimal
+        When I enter the roman number <roman_number>
+        Then it should show me the decimal number <decimal_number>
+
+        Examples: number in roman and decimal
+            | roman_number | decimal_number |
+            |    I         |           1    | 
+            |    V         |           5    | 
+            |    X         |          10    | 
+            |    L         |          50    | 
+            |    C         |         100    | 
+            |    D         |         500    | 
+            |    M         |        1000    | 
+            |    II        |           2    | 
+            |    III       |           3    | 
+            |    XX        |          20    | 
+            |    VI        |           6    | 
+            |    VII       |           7    | 
+            |    VIII      |           8    | 
+            |    IV        |           4    | 
+            |    IX        |           9    | 
+            |    IL        |          49    | 
+            |    MDXC      |        1590    | 
+            |    MCMLXXXIV |        1984    | 
+            |    LII       |          52    | 
+
+

--- a/romanos_20170111/features/steps/roman.py
+++ b/romanos_20170111/features/steps/roman.py
@@ -1,0 +1,13 @@
+from romanos import romanos
+
+
+@when('I enter the roman number {roman_number}')
+def step_impl(context, roman_number):
+    context.decimal_result = romanos(roman_number)
+
+
+@then('it should show me the decimal number {decimal_number:d}')
+def step_impl(context, decimal_number):
+    assert context.decimal_result == decimal_number
+
+


### PR DESCRIPTION
Adicionei os testes em BDD usando behave para os dojos que já existiam.

Para o jokenpo e romanos, implementei *exatamente* os mesmos testes, ficou 1 para 1 e equivalência exata entre unittest e BDD.

Para o fizzbuzz, tinha 3 tipos de teste em unittest, testando a função fizzbuzz, o metódo da classe FizzBuzzInt e ainda o repr() dos objetos da classe. Para os dois ultimos tipos de teste, haviam bem menos metódos de teste, porém como implementei os inputs de forma genérica no BDD, usando tabelas de exemplos, acabei rodando todos os inputs em todos os 3 tipos de teste que estavam em unittest, acabando fazendo até mais testes do que original (um superset).

Adicionei também as instruções de como rodar os testes, tanto em unittest como BDD no README do projeto.


